### PR TITLE
Update coral installation instructions

### DIFF
--- a/en/meta.yml
+++ b/en/meta.yml
@@ -1,14 +1,19 @@
+---
 title: Image classification with Google Coral
 hero_image: images/banner.png
 description: Learn how to retrain a machine learning model and use it for image identification.
 version: 4
 listed: true
 copyedit: true
-last_tested: "2021-03-26"
+last_tested: '2021-03-26'
 steps:
-  - title: Introduction
-  - title: Set up your Coral and gather your images
-  - title: Retrain a model online, with Teachable Machine
-  - title: Retrain a model on your Raspberry Pi
-  - title: Testing your new model
-  - title: Mission Space Lab
+- title: Introduction
+- title: Set up your Coral and gather your images
+- title: Retrain a model online, with Teachable Machine
+  completion:
+  - engaged
+- title: Retrain a model on your Raspberry Pi
+- title: Testing your new model
+  completion:
+  - internal
+- title: Mission Space Lab

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -5,7 +5,8 @@
 There are many machine learning models that have been trained to identify different classes of images. These can easily be retrained to identify new classes.
 </div>
 <div>
-![Three images taken from the ISS showing the Earth in day, night, and twilight.](images/identification.png){:width="300px"} </div>
+![Three images taken from the ISS showing the Earth in day, night, and twilight.](images/identification.png){:width="300px"}
+</div>
 </div>
 
 On your Raspberry Pi, unless you are running an AstroPi Kit OS, you will need to install the software required to use your Coral TPU with Python. If you are running the AstroPi Kit OS, you should skip this step.

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -5,11 +5,10 @@
 There are many machine learning models that have been trained to identify different classes of images. These can easily be retrained to identify new classes.
 </div>
 <div>
-![Three images taken from the ISS showing the Earth in day, night, and twilight.](images/identification.png) {:width="300px"}
-</div>
+![Three images taken from the ISS showing the Earth in day, night, and twilight.](images/identification.png){:width="300px"} </div>
 </div>
 
-On your Raspberry Pi, you will need to install the software required to use your Coral TPU with Python.
+On your Raspberry Pi, unless you are running an AstroPi Kit OS, you will need to install the software required to use your Coral TPU with Python. If you are running the AstroPi Kit OS, you should skip this step.
 
 --- task ---
 


### PR DESCRIPTION
Update the coral installation instructions to try and stop Kit OS users
from deviating their OS from the deployed Flight OS versions - maintaining parity between the Kit OS
and Flight OS should increase the likelihood of programs running correctly on the Astro Pis.